### PR TITLE
Typo fix: "estiamte"

### DIFF
--- a/10_chapter/basicCRN.jl
+++ b/10_chapter/basicCRN.jl
@@ -19,7 +19,7 @@ estMCRN = estM.(lamGrid,seed)
 plot(lamGrid,trueM,
 	c=:black, label="Expected curve")
 plot!(lamGrid,estM0,
-	c=:blue, label="No CRN estiamte")
+	c=:blue, label="No CRN estimate")
 plot!(lamGrid,estMCRN,
 	c=:red, label="CRN estimate", 
 	xlims=(0,1), ylims=(0,0.4), xlabel=L"\lambda", ylabel = "Mean")


### PR DESCRIPTION
Hello :) I found a typo while looking through the book. Figure 10.6 had the word estimate misspelled as estiamte.